### PR TITLE
Fix build for newer Boost versions

### DIFF
--- a/src/SkypeExport/model/skypeparser.h
+++ b/src/SkypeExport/model/skypeparser.h
@@ -22,6 +22,7 @@ namespace fs = boost::filesystem;
 #include <boost/next_prior.hpp> // provides iterator next() which allows us to peek at the next iterator in sequence
 #include <boost/tokenizer.hpp> // provides a way to access tokens in a string
 #include <boost/regex.hpp>
+#include <boost/next_prior.hpp>
 
 // this is the size in bytes of a Skype GUID (used as value for certain database columns)
 #define SKYPEPARSER_GUID_SIZE 32


### PR DESCRIPTION
Build with boost-1.79.0 fails:

```
/tmp/SkypeExport-1.4.0/work/SkypeExport-1.4.0/src/SkypeExport/model/skypeparser_parsing.cpp:935:68: error: ‘next’ is not a member of ‘boost’
  935 |                                                         if( boost::next( identities_it ) != tokens.end() ){ thisEvent.asXHTML << ", "; } // appended after every element except the last one
```

This fixes it.